### PR TITLE
Add `features.requireAuthentication`

### DIFF
--- a/static.json
+++ b/static.json
@@ -12,7 +12,8 @@
         "description": "XPCS Portal test"
       },
       "features": {
-        "jsonata": true
+        "jsonata": true,
+        "requireAuthentication": true
       },
       "theme": {
         "colors": {


### PR DESCRIPTION
This is another optional change.

> Force users to authenticate before accessing the portal, regardless of whether or not the configured Globus Index is private.

It looks like there is a public entry in this index, but that might just be some metadata.


### Current State

<img width="1316" alt="Screenshot 2024-11-07 at 3 06 40 PM" src="https://github.com/user-attachments/assets/7caf6ff1-f171-4909-971f-a6c490809678">


### With `features.requireAuthentication === true`

<img width="1320" alt="Screenshot 2024-11-07 at 3 06 17 PM" src="https://github.com/user-attachments/assets/79c8cc61-89a8-496c-8243-fb12dac00ef4">
